### PR TITLE
match type params so parametrized types can be compared

### DIFF
--- a/astequal.go
+++ b/astequal.go
@@ -4,6 +4,8 @@ package astequal
 import (
 	"go/ast"
 	"go/token"
+
+	"golang.org/x/exp/typeparams"
 )
 
 // Node reports whether two AST nodes are structurally (deep) equal.
@@ -316,7 +318,8 @@ func astFuncTypeEq(x, y *ast.FuncType) bool {
 		return x == y
 	}
 	return astFieldListEq(x.Params, y.Params) &&
-		astFieldListEq(x.Results, y.Results)
+		astFieldListEq(x.Results, y.Results) &&
+		astFieldListEq(typeparams.ForFuncType(x), typeparams.ForFuncType(y))
 }
 
 func astBasicLitEq(x, y *ast.BasicLit) bool {
@@ -675,7 +678,8 @@ func astTypeSpecEq(x, y *ast.TypeSpec) bool {
 	if x == nil || y == nil {
 		return x == y
 	}
-	return astIdentEq(x.Name, y.Name) && astExprEq(x.Type, y.Type)
+	return astIdentEq(x.Name, y.Name) && astExprEq(x.Type, y.Type) &&
+		astFieldListEq(typeparams.ForTypeSpec(x), typeparams.ForTypeSpec(y))
 }
 
 func astValueSpecEq(x, y *ast.ValueSpec) bool {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/go-toolsmith/astequal
 
+go 1.16
+
 require github.com/go-toolsmith/strparse v1.0.0
+
+require golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUDxe2Jb4=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171 h1:DZhP7zSquENyG3Yb6ZpGqNEtgE8dfXhcLcheIF9RQHY=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=


### PR DESCRIPTION
Use typeparams package to keep pre Go1.18 users satisfied.